### PR TITLE
customisable_models

### DIFF
--- a/addresses/app_settings.py
+++ b/addresses/app_settings.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+settings = getattr(settings, 'ADDRESSES_SETTINGS', {})
+
+Address = settings.get("ADDRESS_MODEL", "models.Address")
+Country = settings.get("COUNTRY_MODEL", "models.Country")
+State = settings.get("STATE_MODEL", "models.State")

--- a/addresses/serializers.py
+++ b/addresses/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
-from addresses.models import Address, Country, State
+from app_settings import Address, Country, State
 
 
 class AddressesSerializer(serializers.ModelSerializer):

--- a/addresses/views.py
+++ b/addresses/views.py
@@ -3,12 +3,12 @@ from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 
-from addresses.models import Address, Country, State
 from addresses.serializers import (
     AddressesSerializer,
     CountrySerializer,
     StateSerializer,
 )
+from app_settings import Address, Country, State
 
 
 class AddressViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
Added the ability to specify an alternative model to be used in views and serializers from the `app_settings` file. Allows us to extend each model in the host project, whilst using the same serializers, views, and urls.