### PR TITLE
Customisable serializers

### DIFF
--- a/addresses/app_settings.py
+++ b/addresses/app_settings.py
@@ -1,0 +1,7 @@
+from django.conf import settings
+
+settings = getattr(settings, 'ADDRESSES_SETTINGS', {})
+
+Address = settings.get("ADDRESS_MODEL", "models.Address")
+Country = settings.get("COUNTRY_MODEL", "models.Country")
+State = settings.get("STATE_MODEL", "models.State")

--- a/addresses/app_settings.py
+++ b/addresses/app_settings.py
@@ -1,7 +1,9 @@
 from django.conf import settings
 
+from addresses.serializers import AddressSerializer, CountrySerializer, StateSerializer
+
 settings = getattr(settings, 'ADDRESSES_SETTINGS', {})
 
-Address = settings.get("ADDRESS_MODEL", "models.Address")
-Country = settings.get("COUNTRY_MODEL", "models.Country")
-State = settings.get("STATE_MODEL", "models.State")
+AddressSerializer = settings.get("ADDRESS_SERIALIZER", AddressSerializer)
+CountrySerializer = settings.get("COUNTRY_SERIALIZER", CountrySerializer)
+StateSerializer = settings.get("STATE_SERIALIZER", StateSerializer)

--- a/addresses/serializers.py
+++ b/addresses/serializers.py
@@ -5,9 +5,7 @@ from addresses.models import Address, Country, State
 
 
 class AddressSerializer(serializers.ModelSerializer):
-    """
-    Address Serializer
-    """
+    """Address Serializer"""
 
     content_type = serializers.CharField(write_only=True, required=True)
     app_label = serializers.CharField(write_only=True, required=True)
@@ -84,9 +82,7 @@ class AddressSerializer(serializers.ModelSerializer):
 
 
 class StateSerializer(serializers.ModelSerializer):
-    """
-    State Serializer
-    """
+    """State Serializer"""
 
     class Meta:
         model = State
@@ -99,9 +95,7 @@ class StateSerializer(serializers.ModelSerializer):
 
 
 class CountrySerializer(serializers.ModelSerializer):
-    """
-    Country Serializer
-    """
+    """Country Serializer"""
 
     class Meta:
         model = Country

--- a/addresses/serializers.py
+++ b/addresses/serializers.py
@@ -1,10 +1,10 @@
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
-from app_settings import Address, Country, State
+from addresses.models import Address, Country, State
 
 
-class AddressesSerializer(serializers.ModelSerializer):
+class AddressSerializer(serializers.ModelSerializer):
     """
     Address Serializer
     """

--- a/addresses/serializers.py
+++ b/addresses/serializers.py
@@ -1,7 +1,7 @@
 from django.contrib.contenttypes.models import ContentType
 from rest_framework import serializers
 
-from addresses.models import Address, Country, State
+from app_settings import Address, Country, State
 
 
 class AddressesSerializer(serializers.ModelSerializer):

--- a/addresses/views.py
+++ b/addresses/views.py
@@ -12,9 +12,7 @@ from addresses.app_settings import (
 
 
 class AddressViewSet(viewsets.ModelViewSet):
-    """
-    Customer view set
-    """
+    """Address view set"""
 
     serializer_class = AddressSerializer
     permission_classes = (IsAuthenticated,)
@@ -24,9 +22,7 @@ class AddressViewSet(viewsets.ModelViewSet):
 
 
 class CountryViewSet(viewsets.ModelViewSet):
-    """
-    Country view set
-    """
+    """Country view set"""
 
     serializer_class = CountrySerializer
     permission_classes = (IsAuthenticated,)
@@ -36,9 +32,7 @@ class CountryViewSet(viewsets.ModelViewSet):
 
 
 class StateViewSet(viewsets.ModelViewSet):
-    """
-    State view set
-    """
+    """State view set"""
 
     serializer_class = StateSerializer
     permission_classes = (IsAuthenticated,)
@@ -48,9 +42,7 @@ class StateViewSet(viewsets.ModelViewSet):
 
 
 def get_district_from_postcode(postcode):
-    """
-    function to get the district from a postcode
-    """
+    """function to get the district from a postcode"""
     if settings.APP_LOCATION == "LONDON":
         try:
             stripped_postcode = postcode.replace(" ", "").upper()

--- a/addresses/views.py
+++ b/addresses/views.py
@@ -3,12 +3,12 @@ from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 
-from addresses.models import Address, Country, State
 from addresses.serializers import (
     AddressesSerializer,
     CountrySerializer,
     StateSerializer,
 )
+from app_settings import Address, Country, State
 
 
 class AddressViewSet(viewsets.ModelViewSet):

--- a/addresses/views.py
+++ b/addresses/views.py
@@ -3,12 +3,12 @@ from rest_framework import viewsets, status
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 
-from addresses.serializers import (
-    AddressesSerializer,
+from addresses.models import Address, Country, State
+from addresses.app_settings import (
+    AddressSerializer,
     CountrySerializer,
     StateSerializer,
 )
-from app_settings import Address, Country, State
 
 
 class AddressViewSet(viewsets.ModelViewSet):
@@ -16,7 +16,7 @@ class AddressViewSet(viewsets.ModelViewSet):
     Customer view set
     """
 
-    serializer_class = AddressesSerializer
+    serializer_class = AddressSerializer
     permission_classes = (IsAuthenticated,)
 
     def get_queryset(self):


### PR DESCRIPTION
Added the ability to specify an alternative serializer to be used in views. Allows us to extend each serializer from the host project, whilst using the same models, views, and urls.