### PR TITLE
fix_app_settings_import_error

### DIFF
--- a/addresses/app_settings.py
+++ b/addresses/app_settings.py
@@ -1,9 +1,17 @@
+from importlib import import_module
+
 from django.conf import settings
 
 from addresses.serializers import AddressSerializer, CountrySerializer, StateSerializer
 
+
+def import_from_path(path):
+    package, attr = path.rsplit('.', 1)
+    return getattr(import_module(package), attr)
+
+
 settings = getattr(settings, 'ADDRESSES_SETTINGS', {})
 
-AddressSerializer = settings.get("ADDRESS_SERIALIZER", AddressSerializer)
-CountrySerializer = settings.get("COUNTRY_SERIALIZER", CountrySerializer)
-StateSerializer = settings.get("STATE_SERIALIZER", StateSerializer)
+AddressSerializer = import_from_path(settings.get("ADDRESS_SERIALIZER", AddressSerializer))
+CountrySerializer = import_from_path(settings.get("COUNTRY_SERIALIZER", CountrySerializer))
+StateSerializer = import_from_path(settings.get("STATE_SERIALIZER", StateSerializer))


### PR DESCRIPTION
Fixes issue where attempting to import Serializer class from settings before django has loaded in host project. Adds ability for custom serializers to be defined as and imported from a path string, to avoid this issue.